### PR TITLE
Nn bug referentiewaarden

### DIFF
--- a/code/labflow-backend/src/main/java/com/thomasmore/blc/labflow/config/DataLoader.java
+++ b/code/labflow-backend/src/main/java/com/thomasmore/blc/labflow/config/DataLoader.java
@@ -420,7 +420,6 @@ public class DataLoader implements CommandLineRunner {
         referentiewaardeRepository.save(new Referentiewaarde("Kell +/-", test65));
 
         referentiewaardeRepository.save(new Referentiewaarde(" +/-", test66));
-        referentiewaardeRepository.save(new Referentiewaarde("hier graag een tekstvlak om zelf uitslag in te typen", test67));
         referentiewaardeRepository.save(new Referentiewaarde(" +/-", test68));
 
         // Hemostase (citraat)
@@ -431,7 +430,6 @@ public class DataLoader implements CommandLineRunner {
         referentiewaardeRepository.save(new Referentiewaarde("man 0-5", test221));
         referentiewaardeRepository.save(new Referentiewaarde("vrouw 0-7", test221));
         referentiewaardeRepository.save(new Referentiewaarde(" +/-", test222));
-        referentiewaardeRepository.save(new Referentiewaarde("hier graag een tekstvlak om zelf uitslag in te typen", test223));
         referentiewaardeRepository.save(new Referentiewaarde(" +/-", test224));
 
         // Serologie Viraal (serum)
@@ -440,17 +438,6 @@ public class DataLoader implements CommandLineRunner {
 
         // Serologie Bacterieel (serum)
         referentiewaardeRepository.save(new Referentiewaarde("positief >200", test270));
-
-        // Flow cytometrie (EDTA)
-        referentiewaardeRepository.save(new Referentiewaarde("hier graag een tekstvlak om zelf uitslag in te typen", test727));
-        referentiewaardeRepository.save(new Referentiewaarde("hier graag een tekstvlak om zelf uitslag in te typen", test728));
-
-        // Genetica
-        referentiewaardeRepository.save(new Referentiewaarde("hier graag een tekstvlak om zelf uitslag in te typen", test729));
-
-        // Metabole aandoeningen
-        referentiewaardeRepository.save(new Referentiewaarde("hier graag een tekstvlak om zelf uitslag in te typen", test730));
-
         // Biochemie - Suikers
         referentiewaardeRepository.save(new Referentiewaarde("70-105", test100));
         referentiewaardeRepository.save(new Referentiewaarde("4-6%", test103));
@@ -498,7 +485,6 @@ public class DataLoader implements CommandLineRunner {
         referentiewaardeRepository.save(new Referentiewaarde("Alfa-2 globulinen: 7.4-12.6%", test162));
         referentiewaardeRepository.save(new Referentiewaarde("Bèta globulinen: 7.5-12.9%", test162));
         referentiewaardeRepository.save(new Referentiewaarde("Gamma globulinen: 8-15.8%", test162));
-        referentiewaardeRepository.save(new Referentiewaarde("hier graag een tekstvlak om zelf uitslag in te typen", test163));
 
         referentiewaardeRepository.save(new Referentiewaarde("<5", test164)); // CRP
         referentiewaardeRepository.save(new Referentiewaarde("30-100", test210)); // Vit. D3 (25-OH)

--- a/code/labflow-backend/src/main/java/com/thomasmore/blc/labflow/repository/ReferentiewaardeRepository.java
+++ b/code/labflow-backend/src/main/java/com/thomasmore/blc/labflow/repository/ReferentiewaardeRepository.java
@@ -11,5 +11,5 @@ public interface ReferentiewaardeRepository extends JpaRepository<Referentiewaar
 
     void removeReferentiewaardeById(Long id);
 
-
+    Referentiewaarde findReferentiewaardeByWaarde(String s);
 }

--- a/code/labflow-backend/src/main/java/com/thomasmore/blc/labflow/service/PdfGeneratorService.java
+++ b/code/labflow-backend/src/main/java/com/thomasmore/blc/labflow/service/PdfGeneratorService.java
@@ -350,7 +350,7 @@ public class PdfGeneratorService {
 
             // afhankelijk van het aantal referentiewaardes, deze samenvoegen en toevoegen aan de tabel
             assert referentiewaardes != null;
-            if (referentiewaardes.isEmpty()) {
+            if (!referentiewaardes.isEmpty()) {
                 // stream voor tussen elke referentiewaarde een '/' te plaatsen
                 String referentieWaarden = referentiewaardes.stream()
                         .map(Referentiewaarde::getWaarde)

--- a/code/labflow-frontend/src/components/Instellingen/Testsbeheren.svelte
+++ b/code/labflow-frontend/src/components/Instellingen/Testsbeheren.svelte
@@ -55,11 +55,18 @@
 		// mappen van referentiewaarden overeenkomstig de waarden die in de multiselect moeten komen
 		if (fetchedReferentiewaardes) {
 			referentiewaardes = fetchedReferentiewaardes;
-			waarden = referentiewaardes.map((item) => ({
-				id: item.id,
-				label: item.waarde,
-				waarde: item.waarde
-			}));
+			// we willen geen dubbele referentiewaarden, dus we gebruiken een Map om unieke waarden te bewaren
+			const uniqueWaardenMap = new Map();				
+			for (const item of referentiewaardes) {
+				if (!uniqueWaardenMap.has(item.waarde)) {
+					uniqueWaardenMap.set(item.waarde, {
+						id: item.id,
+						label: item.waarde,
+						waarde: item.waarde
+					});
+				}
+			}
+			waarden = Array.from(uniqueWaardenMap.values());
 		}
 	});
 

--- a/code/labflow-frontend/src/components/Instellingen/modalReferentiewaarden/Modal.svelte
+++ b/code/labflow-frontend/src/components/Instellingen/modalReferentiewaarden/Modal.svelte
@@ -70,7 +70,6 @@
 				<strong>Kies je referentiewaardes:</strong>
 			</label>
 			<MultiSelect
-				style="height: 60px;"
 				id="referentiewaarden"
 				options={waarden}
 				bind:value={$selectedValues}
@@ -107,11 +106,11 @@
 <style>
 	dialog {
 		position: fixed;
-		top: 50%;
+		top: 60%;
 		left: 50%;
 		transform: translate(-50%, -50%);
 		max-width: 90vw;
-		max-height: 60vh;
+		max-height: 70vh;
 		width: 60em;
 		height: 100em;
 		border: none;


### PR DESCRIPTION
- Referentiewaarde 'hier graag een tekstvlak om zelf uitslag in te typen' weggehaald want dit hebben we toegevoegd met de test 'notitie'.
- Popup van referentiewaarden gemaakt, zodat de dropdown niet verdween onder de popup.
- Toon alleen unieke referentiewaarden in de dropdown, de duplicaten hebben geen zin.
- Bug gefixt dat referentiewaarden niet toegevoegd werden in de pdf.